### PR TITLE
  Preload text tags for product attributes in variant related fields 

### DIFF
--- a/FieldtypePWCommerceProductStock/InputfieldPWCommerceProductStock.module
+++ b/FieldtypePWCommerceProductStock/InputfieldPWCommerceProductStock.module
@@ -607,12 +607,12 @@ EOT;
 		// TODO ADD HTMX HERE ON ON PARENT DIV ABOVE?
 		$out = "
 			<div id='pwcommerce_product_attribute_options_list{$attribute->id}'>" .
-			$this->buildProductAttributeOptionsAutocomplete($attribute, $attributeOptionsInExistingVariants) .
+			$this->buildProductAttributeOptions($attribute, $attributeOptionsInExistingVariants) .
 			"</div>";
 		return $out;
 	}
 
-	private function buildProductAttributeOptionsAutocomplete($attribute, $attributeOptionsInExistingVariants) {
+	private function buildProductAttributeOptions($attribute, $attributeOptionsInExistingVariants) {
 
 		$attributeID = $attribute->id;
 
@@ -631,10 +631,7 @@ EOT;
 		$customHookURL = "/find-pwcommerce_product_attributes/";
 		$tagsURL = "{$customHookURL}?id={$pageID}&field={$name}&parent_id={$attributeID}&context=options&q={q}";
 		$label = sprintf(__("%s options"), $attribute->title);
-		//   $placeholder = $this->_('Start typing to search.');
-		//   $placeholder = sprintf(__("Begin typing to search for %s options"), mb_strtolower($attribute->title));
-		// TODO: REPHRASE?
-		$placeholder = sprintf(__("Type at least 3 characters to search for %s options"), mb_strtolower($attribute->title));
+		$placeholder = sprintf(__("Click to select %s options"), mb_strtolower($attribute->title));
 		//--------------
 
 		$optionsTextTags = [
@@ -668,6 +665,21 @@ EOT;
 			$field->val(array_keys($attributeOptionsInExistingVariants));
 			$field->setTagsList($attributeOptionsInExistingVariants);
 		}
+
+
+		// Preload list of tags
+		$tagPages = $this->wire->pages->get($pageSelector)->siblings()->getArray();
+
+		$tagOptions = array_reduce($tagPages, function($options, $tagPage) {
+			$options[$tagPage->id] = $tagPage->title;
+
+			return $options;
+		}, []);
+
+		if (count($tagOptions)) {
+			$field->addOptions($tagOptions);
+		}
+
 		// TODO:  TEST IF CAN ADD ATTRS HERE, E.G. ref for ALPINE JS, ETC - yes we can but they don't get fired since changes are made programmatically by selectize and not the user!
 		//   $field->attr('x-on:input', 'something');
 		//   $field->attr('x-on:change', 'another');


### PR DESCRIPTION
**What**
This changes the behavior of how text tags are rendered for product variant fields. Rather than load variant tags using AJAX on input, the tags are loaded as options and rendered on page load making them available when clicking on the field.

**Why**
I'm not sure if pre-rendering was previously considered but this solves two issues that I encountered.

Variants become unusable when the name of the attribute is shorter than 3 characters or is 3 characters and one is a non-alphanumeric character. An example is length such as 12"
image

<img width="464" height="336" alt="Screenshot From 2025-07-13 10-03-57" src="https://github.com/user-attachments/assets/536a722b-6b4d-40c0-af0f-31d1d0b729be" />

The second field will not populate even if a correct value such as 12" is entered, it will blank on loss of focus.

Values such as 12", 20", 30", etc. could never be accessed when configuring variations for a product because the value of 10 is shorter than the 3 letter AJAX cutoff and (some? all?) non-alphanumeric characters are stripped for the AJAX request.

The second improvement that this brings is making is easier to use variants that have many options. I found myself forgetting the names of some the variants so I had to reference the configuration page. It's also possible to not be aware of all of the variants because the user may not be familiar with the shop, or has never seen the variants before. In the case of the lengths example, it would be easy to intend to add all lengths as variations but not typing all of the needed characters, i.e. typing 10", 12", 20", but forgetting or not being aware of 30" so those are never seen by the user.

**What Changed**
Pre-rendering the tags on page load, disabling AJAX in the InputfieldTextTags config for attribute options, and updating the method name to reflect the new behavior.

**Additional Considerations**
I'm not sure if this makes the AJAX endpoint located in PwCommerceHooks::hookFindPWCommerceProductAttributesOptions() unnecessary so that was kept as is.

**Result**

<img width="506" height="521" alt="Screenshot From 2025-07-13 10-42-26" src="https://github.com/user-attachments/assets/f22c0780-7a6c-4c50-ac1c-215f7df72193" />
