### PR TITLE
Add CONTRIBUTING.md adapted from ProcessWire guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to ProcessWire Commerce
+
+Thank you for your interest in contributing to ProcessWire Commerce via issue reports, feature requests, or pull requests.
+
+## Issue Reports
+
+- Submit ProcessWire Commerce issue reports to the issues repository:
+  [ProcessWireCommerce Issues](https://github.com/kongondo/ProcessWireCommerce/issues)
+
+- Please do not use the issues repository for ProcessWire Commerce support, instead use the support forum:
+  <https://processwire.com/talk/forum/62-pwcommerce-support/>
+
+- Always include the full ProcessWire Commerce version. Also include the ProcessWire version and PHP or MySQL version when potentially applicable.
+
+- Indicate any 3rd party modules that are installed.
+
+- When possible please confirm the issue on a separate installation before submitting an issue report.
+
+- When the issue is resolved, please close it.
+
+
+## Feature Requests
+
+- Submit feature requests to the repository:
+  [ProcessWireCommerce Issues](https://github.com/kongondo/ProcessWireCommerce/issues)
+
+- Please note that we generally avoid adding features that aren't going to be used by at least 30% of the ProcessWire Commerce audience. Often new features can be better accommodated with modules.
+
+- If we close your feature request, this does not mean it won't ever be implemented. It just means that we aren't ready to implement it just yet. Closed feature requests aren't ever deleted, so consider closed feature requests to just be on the back burner.
+
+- Sometimes we will leave a feature request open for awhile to see how much interest it gains from others before we decide whether it should be implemented.
+
+
+## Pull Requests (PRs)
+
+- Pull requests should be submitted to the [ProcessWireCommerce](https://github.com/kongondo/ProcessWireCommerce/pulls) repository, and based on the [dev branch](https://github.com/kongondo/ProcessWireCommerce/tree/dev).
+
+- See the ProcessWire [Coding Style Guide](https://processwire.com/docs/more/coding-style-guide/) before submitting a PR. While it's not required that you adhere to the style guide, it does increase the odds that we may be able to directly merge your PR.
+
+- **Important Exception:** This project utilizes the ProcessWire Coding Style Guide with one exception: **constants must be named as `UPPER_SNAKE_CASE`**.
+
+- Please only submit code that you feel confident is stable and you have thoroughly tested. Verbose code comments are also appreciated when possible.
+
+- In many cases we do not directly merge pull requests with our established workflow. If we do not directly merge the pull request, but do add the proposed features/changes, you will still be fully credited directly in the commit message.


### PR DESCRIPTION
Added `CONTRIBUTING.md` file adapted from ProcessWire's guide for ProcessWire Commerce project. Specifically, it includes the requirement for `UPPER_SNAKE_CASE` constants as requested.

---
*PR created automatically by Jules for task [3637808337839805513](https://jules.google.com/task/3637808337839805513) started by @kongondo*