### PR TITLE
Merge dev into main

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+custom: ["https://processwireshop.pw/products/thank-you/", processwireshop.pw]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to ProcessWire Commerce
+
+Thank you for your interest in contributing to ProcessWire Commerce via issue reports, feature requests, or pull requests.
+
+## Issue Reports
+
+- Submit ProcessWire Commerce issue reports to the issues repository:
+  [ProcessWireCommerce Issues](https://github.com/kongondo/ProcessWireCommerce/issues)
+
+- Please do not use the issues repository for ProcessWire Commerce support, instead use the support forum:
+  <https://processwire.com/talk/forum/62-pwcommerce-support/>
+
+- Always include the full ProcessWire Commerce version. Also include the ProcessWire version and PHP or MySQL version when potentially applicable.
+
+- Indicate any 3rd party modules that are installed.
+
+- When possible please confirm the issue on a separate installation before submitting an issue report.
+
+- When the issue is resolved, please close it.
+
+
+## Feature Requests
+
+- Submit feature requests to the repository:
+  [ProcessWireCommerce Issues](https://github.com/kongondo/ProcessWireCommerce/issues)
+
+- Please note that we generally avoid adding features that aren't going to be used by at least 30% of the ProcessWire Commerce audience. Often new features can be better accommodated with modules.
+
+- If we close your feature request, this does not mean it won't ever be implemented. It just means that we aren't ready to implement it just yet. Closed feature requests aren't ever deleted, so consider closed feature requests to just be on the back burner.
+
+- Sometimes we will leave a feature request open for awhile to see how much interest it gains from others before we decide whether it should be implemented.
+
+
+## Pull Requests (PRs)
+
+- Pull requests should be submitted to the [ProcessWireCommerce](https://github.com/kongondo/ProcessWireCommerce/pulls) repository, and based on the [dev branch](https://github.com/kongondo/ProcessWireCommerce/tree/dev).
+
+- See the ProcessWire [Coding Style Guide](https://processwire.com/docs/more/coding-style-guide/) before submitting a PR. While it's not required that you adhere to the style guide, it does increase the odds that we may be able to directly merge your PR.
+
+- **Important Exception:** This project utilizes the ProcessWire Coding Style Guide with one exception: **constants must be named as `UPPER_SNAKE_CASE`**.
+
+- Please only submit code that you feel confident is stable and you have thoroughly tested. Verbose code comments are also appreciated when possible.
+
+- In many cases we do not directly merge pull requests with our established workflow. If we do not directly merge the pull request, but do add the proposed features/changes, you will still be fully credited directly in the commit message.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Francis Otieno
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@
 
 Mono repo for ProcessWire Commerce, the feature-rich native full e-commerce solution for ProcessWire.
 
+ProcessWire Commerce is a free, open-source fully featured e-commerce module (plugin) for building and managing fully function online shops (stores) in ProcessWire. It is flexible, extensible, highly customisable, scalable, robust, multilingual by design and battle tested.
+
 ## Version
 
 100
+
+## Requirements
+
+- PHP>=7.4.0 with BC Math extension
+- ProcessWire>=3.0.184
+- Modern browser (backend only)
 
 ## Demo
 
@@ -20,6 +28,6 @@ WIP
 
 https://docs.kongondo.com/
 
-## Support Forum
+## Community Support Forum
 
 https://processwire.com/talk/forum/62-pwcommerce-support/


### PR DESCRIPTION
Merged `dev` into `main` using `--allow-unrelated-histories` due to disjoint history. 

Resolved conflict in `README.md` by combining the detailed description and requirements from `main` with the documentation link from `dev`.

Other files were merged cleanly as they were either identical or unique to one branch.
Verified that `dev` was missing `CONTRIBUTING.md`, `LICENSE`, and `.github/FUNDING.yml`, which are retained from `main`.

---
*PR created automatically by Jules for task [16358806440505650436](https://jules.google.com/task/16358806440505650436) started by @kongondo*