### PR TITLE
Preload product attribute options for variants

### DIFF
--- a/FieldtypePWCommerceProductStock/InputfieldPWCommerceProductStock.module
+++ b/FieldtypePWCommerceProductStock/InputfieldPWCommerceProductStock.module
@@ -607,12 +607,12 @@ EOT;
 		// TODO ADD HTMX HERE ON ON PARENT DIV ABOVE?
 		$out = "
 			<div id='pwcommerce_product_attribute_options_list{$attribute->id}'>" .
-			$this->buildProductAttributeOptionsAutocomplete($attribute, $attributeOptionsInExistingVariants) .
+			$this->buildProductAttributeOptions($attribute, $attributeOptionsInExistingVariants) .
 			"</div>";
 		return $out;
 	}
 
-	private function buildProductAttributeOptionsAutocomplete($attribute, $attributeOptionsInExistingVariants) {
+	private function buildProductAttributeOptions($attribute, $attributeOptionsInExistingVariants) {
 
 		$attributeID = $attribute->id;
 
@@ -631,10 +631,7 @@ EOT;
 		$customHookURL = "/find-pwcommerce_product_attributes/";
 		$tagsURL = "{$customHookURL}?id={$pageID}&field={$name}&parent_id={$attributeID}&context=options&q={q}";
 		$label = sprintf(__("%s options"), $attribute->title);
-		//   $placeholder = $this->_('Start typing to search.');
-		//   $placeholder = sprintf(__("Begin typing to search for %s options"), mb_strtolower($attribute->title));
-		// TODO: REPHRASE?
-		$placeholder = sprintf(__("Type at least 3 characters to search for %s options"), mb_strtolower($attribute->title));
+		$placeholder = sprintf(__("Click to select %s options"), mb_strtolower($attribute->title));
 		//--------------
 
 		$optionsTextTags = [
@@ -668,6 +665,19 @@ EOT;
 			$field->val(array_keys($attributeOptionsInExistingVariants));
 			$field->setTagsList($attributeOptionsInExistingVariants);
 		}
+
+		// Preload list of tags
+		$tagPages = $this->wire('pages')->findRaw("template=pwcommerce-attribute-option,parent_id={$attributeID}, status<" . Page::statusTrash, ['title']);
+
+		$tagOptions = [];
+		foreach ($tagPages as $id => $values) {
+			$tagOptions[$id] = $values['title'];
+		}
+
+		if (count($tagOptions)) {
+			$field->addOptions($tagOptions);
+		}
+
 		// TODO:  TEST IF CAN ADD ATTRS HERE, E.G. ref for ALPINE JS, ETC - yes we can but they don't get fired since changes are made programmatically by selectize and not the user!
 		//   $field->attr('x-on:input', 'something');
 		//   $field->attr('x-on:change', 'another');


### PR DESCRIPTION
Applied changes from PR #6 to preload product attribute options, fixing issues with short attribute names not being searchable via AJAX.
Updated `FieldtypePWCommerceProductStock/InputfieldPWCommerceProductStock.module`:
- Renamed `buildProductAttributeOptionsAutocomplete` to `buildProductAttributeOptions`.
- Implemented option preloading logic using `$this->wire->pages->findRaw(...)` to populate the `InputfieldTextTags` field options.
- Updated placeholder text to reflect the change from "Type to search" to "Click to select".

---
*PR created automatically by Jules for task [1802107423911753586](https://jules.google.com/task/1802107423911753586) started by @kongondo*