### PR TITLE
Remove GitHub Sponsors configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-custom: ["https://processwireshop.pw/products/thank-you/", processwireshop.pw]


### PR DESCRIPTION
This PR removes the `.github/FUNDING.yml` file, which disables the GitHub Sponsors feature for this repository. This action was taken to fulfill the request to remove project sponsorship configuration.

---
*PR created automatically by Jules for task [9686834187478408308](https://jules.google.com/task/9686834187478408308) started by @kongondo*