### PR TITLE
Initialize MkDocs documentation structure and automated deployment

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1. Build MkDocs Site (Creates 'site/' directory)
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install MkDocs and Material Theme
+        run: pip install mkdocs-material
+
+      - name: Build MkDocs
+        run: mkdocs build
+
+      # 2. Generate PHP API Documentation (Into 'site/api/')
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: phpDocumentor
+
+      - name: Generate API Docs
+        run: phpdoc -d . -t site/api --ignore "vendor/,node_modules/,site/,docs/,tests/,test/,.git/,.github/" --template="default"
+
+      # 3. Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/docs/admin/index.md
+++ b/docs/admin/index.md
@@ -1,0 +1,34 @@
+# Admin Guide
+
+Welcome to the ProcessWire Commerce Admin Guide. This section covers installation, configuration, and daily management tasks for your store.
+
+## Installation
+
+### Requirements
+
+*   PHP >= 7.4.0 (with BC Math extension)
+*   ProcessWire >= 3.0.184
+*   Modern browser (backend only)
+
+### Steps
+
+1.  **Download:** Obtain the module files.
+2.  **Upload:** Place the module folder in your `site/modules/` directory.
+3.  **Install:** Log in to your ProcessWire admin, go to **Modules > Refresh**, and install **ProcessPWCommerce**.
+4.  **Setup:** Follow the on-screen instructions to complete the initial setup wizard.
+
+## Configuration
+
+After installation, visit the **Shop > Settings** page to configure:
+*   Currency
+*   Tax settings
+*   Payment gateways
+*   Shipping methods
+
+## Managing Your Store
+
+Use the **Shop** menu to access:
+*   [Products](products.md)
+*   Orders
+*   Customers
+*   Discounts

--- a/docs/admin/products.md
+++ b/docs/admin/products.md
@@ -1,0 +1,29 @@
+# Managing Products
+
+This guide explains how to create, edit, and manage products in your ProcessWire Commerce store.
+
+## Creating a Product
+
+1.  Navigate to **Shop > Products > Add New**.
+2.  Fill in the **Product Name** and basic details.
+3.  Select a **Product Template** (if applicable).
+4.  Click **Save**.
+
+## Product Fields
+
+*   **SKU:** Stock Keeping Unit (unique identifier).
+*   **Price:** Base price of the product.
+*   **Stock:** Quantity available.
+*   **Categories:** Assign categories for organization.
+*   **Images:** Upload product images.
+
+## Product Variants
+
+Learn how to create variations (e.g., Size, Color) for your products.
+
+## Bulk Actions
+
+Use the **Shop > Products** list to perform bulk actions:
+*   Update stock
+*   Change prices
+*   Delete products

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,34 @@
+# Contributing to the Documentation
+
+We welcome contributions to the ProcessWire Commerce documentation! This guide explains how you can help improve our docs.
+
+## Getting Started
+
+1.  **Fork the Repository:** Create a fork of the [ProcessWire Commerce Repository](https://github.com/kongondo/PWCommerce2Starter).
+2.  **Clone Your Fork:** Clone your forked repository to your local machine.
+3.  **Create a Branch:** Create a new branch for your changes (e.g., `docs/fix-typo`).
+4.  **Edit Files:** Make your changes to the Markdown files in the `docs/` directory.
+5.  **Commit and Push:** Commit your changes and push them to your fork.
+6.  **Submit a Pull Request:** Open a Pull Request from your branch to the main repository's `dev` branch.
+
+## Markdown Format
+
+Documentation is written in Markdown.
+
+## Importing from Word/Other Formats
+
+If you have documentation in Word or other formats, you can convert it to Markdown using tools like [Pandoc](https://pandoc.org/).
+
+### Using Pandoc
+
+To convert a Word document (`.docx`) to Markdown:
+
+```bash
+pandoc my-doc.docx -f docx -t markdown -o my-doc.md
+```
+
+You can then copy the content of `my-doc.md` into the appropriate file in the `docs/` directory.
+
+### Online Converters
+
+There are also online tools available, such as [Word to Markdown Converter](https://word2md.com/).

--- a/docs/developer/api-reference.md
+++ b/docs/developer/api-reference.md
@@ -1,0 +1,5 @@
+# Developer API Reference
+
+This page will provide a detailed reference to the ProcessWire Commerce API, generated from source code comments.
+
+[Click here for the full API Documentation](../../api/index.html)

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,0 +1,33 @@
+# Developer API
+
+Welcome to the ProcessWire Commerce Developer API documentation.
+
+## Overview
+
+This section is for developers who want to extend or customize the functionality of ProcessWire Commerce.
+
+## API Reference
+
+The full API reference, generated from the source code, can be found [here](../api/index.html).
+
+## Extending Classes
+
+You can extend core classes to modify behavior.
+
+```php
+class MyProduct extends ProcessPWCommerce\Product {
+    // Override methods
+}
+```
+
+## Creating Custom Actions
+
+Create custom actions for products, orders, etc., by implementing the `ProcessPWCommerce\Action` interface.
+
+```php
+class MyAction extends ProcessPWCommerce\Action {
+    public function execute($item) {
+        // ...
+    }
+}
+```

--- a/docs/frontend/api-variables.md
+++ b/docs/frontend/api-variables.md
@@ -1,0 +1,47 @@
+# Frontend API Variables
+
+ProcessWire Commerce provides several API variables to help you interact with the store data in your templates.
+
+## Main Variables
+
+*   **`$pwcommerce`:** The main entry point to ProcessWire Commerce functionality. This variable is automatically available in your templates.
+    *   **`$pwcommerce->getCart()`**: Returns the current shopping cart object.
+    *   **`$pwcommerce->getCustomer()`**: Returns the current customer object.
+    *   **`$pwcommerce->import($items, $importType, $options)`**: Import items (e.g. products) into the store.
+    *   **`$pwcommerce->renderAddToCartButton($product)`**: Renders an "Add to Cart" button for a given product.
+
+## Product Object
+
+When working with products (which are standard ProcessWire pages with the `product` template), you have access to standard ProcessWire fields plus Commerce-specific properties:
+
+*   **`$product->title`**: The product name.
+*   **`$product->pw_sku`**: The product's Stock Keeping Unit.
+*   **`$product->pw_price`**: The product's price.
+*   **`$product->pw_stock`**: Current stock level.
+*   **`$product->pw_images`**: Field containing product images.
+
+## Cart Object
+
+The cart object allows you to manage items in the customer's session.
+
+*   **`$cart->items()`**: Returns an array of items in the cart.
+*   **`$cart->getTotal()`**: Returns the total price of the cart.
+*   **`$cart->getNumberOfItems()`**: Returns the total count of items.
+*   **`$cart->add($product, $qty)`**: Add a product to the cart programmatically.
+
+## Example Usage
+
+```php
+<?php
+// Get the cart
+$cart = $pwcommerce->getCart();
+
+// Check if cart is empty
+if($cart->getNumberOfItems() > 0) {
+    echo "You have items in your cart!";
+    echo "Total: " . $cart->getTotal();
+} else {
+    echo "Your cart is empty.";
+}
+?>
+```

--- a/docs/frontend/fetching-products.md
+++ b/docs/frontend/fetching-products.md
@@ -1,0 +1,45 @@
+# Fetching Products
+
+This guide explains how to query and display products in your ProcessWire templates using the ProcessWire API and ProcessWire Commerce methods.
+
+## Basic Querying
+
+Use the standard `pages->find()` method with specific selectors:
+
+```php
+// Find all active products
+$products = $pages->find("template=product, limit=12");
+
+// Find products in a specific category
+$category = $pages->get("/categories/electronics/");
+$products = $pages->find("template=product, categories=$category");
+```
+
+## Rendering Products
+
+You can access product fields directly or use the `render()` method for standardized output:
+
+```php
+foreach($products as $product) {
+    echo "<h2>{$product->title}</h2>";
+    echo "<p>Price: {$product->price}</p>";
+    // Add to cart button
+    echo $modules->get('PwCommerce')->renderAddToCartButton($product);
+}
+```
+
+## Advanced Queries
+
+*   **Sorting:** `sort=price` or `sort=-created`
+*   **Filtering:** `price>100`, `stock>0`
+
+## Dynamic Interactions (HTMX & Alpine.js)
+
+ProcessWire Commerce supports dynamic loading and interactions. Ensure you include the necessary scripts in your template if you wish to use these features.
+
+```html
+<!-- Example HTMX attributes -->
+<div hx-get="/shop/products/" hx-trigger="load">
+    <!-- Products will be loaded here via AJAX -->
+</div>
+```

--- a/docs/frontend/index.md
+++ b/docs/frontend/index.md
@@ -1,0 +1,27 @@
+# Frontend Guide
+
+Welcome to the ProcessWire Commerce Frontend Guide. This section explains how to fetch products and display them in your ProcessWire templates.
+
+## Overview
+
+ProcessWire Commerce uses the `pwcommerce` API variable to interact with your store data. It leverages Alpine.js and HTMX for dynamic frontend interactions, but can also work without JavaScript.
+
+## Getting Started
+
+1.  **Fetching Products:** [Learn how to query products](fetching-products.md).
+2.  **Using API Variables:** [Discover available methods and properties](api-variables.md).
+3.  **Dynamic Interactions:** [Integrate Alpine.js and HTMX](fetching-products.md#dynamic-interactions-htmx-alpinejs).
+4.  **Non-JS Support:** [Build a functional store without JavaScript](js-disabled.md).
+
+## Example Template
+
+```php
+<?php
+// Example of a basic product listing template
+$products = $pages->find("template=product, limit=12");
+
+foreach($products as $product) {
+    echo $product->render(); // Or custom markup
+}
+?>
+```

--- a/docs/frontend/js-disabled.md
+++ b/docs/frontend/js-disabled.md
@@ -1,0 +1,32 @@
+# Non-JS Implementation
+
+ProcessWire Commerce is designed to work seamlessly without JavaScript. This guide explains how to ensure your store remains functional for users with JavaScript disabled.
+
+## Server-Side Rendering
+
+All interactions in ProcessWire Commerce are processed server-side. Forms submit to the server, pages reload, and the state is updated.
+
+## Forms and Buttons
+
+Ensure your forms have a valid `action` attribute and `method="post"`.
+
+```html
+<form action="./add-to-cart/" method="post">
+    <input type="hidden" name="product_id" value="<?php echo $product->id; ?>">
+    <input type="number" name="qty" value="1">
+    <button type="submit">Add to Cart</button>
+</form>
+```
+
+## Navigation
+
+Links should always point to full URLs, not just JavaScript handlers.
+
+```html
+<a href="/cart/">View Cart</a>
+```
+
+## Considerations
+
+*   **Ajax Features:** Features relying purely on Ajax/HTMX will degrade gracefully to full page loads.
+*   **Validation:** Ensure server-side validation is robust, as client-side validation won't run without JS.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# ProcessWire Commerce
+
+ProcessWire Commerce is a free, open-source fully featured e-commerce module (plugin) for building and managing fully function online shops (stores) in ProcessWire. It is flexible, extensible, highly customisable, scalable, robust, multilingual by design and battle tested.
+
+## Project Links
+
+*   **Repository:** [GitHub](https://github.com/kongondo/PWCommerce2Starter)
+*   **Support Forum:** [ProcessWire Talk](https://processwire.com/talk/forum/62-pwcommerce-support/)
+*   **Official Docs:** [kongondo.com](https://docs.kongondo.com/)
+
+## Getting Started
+
+Check out the sections in the navigation to learn more about setting up and using ProcessWire Commerce.
+
+*   **[Admin Guide](admin/index.md):** Learn how to install and manage your store.
+*   **[Frontend Guide](frontend/index.md):** Learn how to build your storefront.
+*   **[Developer API](developer/index.md):** Deep dive into the code.
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guide](contributing.md) for details on how to help improve this documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,52 @@
+site_name: ProcessWire Commerce Documentation
+site_url: https://your-site.github.io/ProcessPWCommerce/
+repo_url: https://github.com/kongondo/PWCommerce2Starter
+repo_name: ProcessPWCommerce
+edit_uri: edit/dev/docs/
+
+theme:
+  name: material
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      primary: teal
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - scheme: slate
+      primary: teal
+      accent: lime
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.expand
+    - navigation.indexes
+
+nav:
+  - Home: index.md
+  - Contributing: contributing.md
+  - Admin Guide:
+    - Introduction: admin/index.md
+    - Managing Products: admin/products.md
+  - Frontend Guide:
+    - Introduction: frontend/index.md
+    - Fetching Products: frontend/fetching-products.md
+    - API Variables: frontend/api-variables.md
+    - Non-JS Implementation: frontend/js-disabled.md
+  - Developer API:
+    - Overview: developer/index.md
+    - Reference: developer/api-reference.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
+copyright: Copyright &copy; 2025 Francis Otieno (Kongondo)

--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/3.0/schemas/phpdoc.xsd">
+    <paths>
+        <output>site/api</output>
+        <cache>.phpdoc/cache</cache>
+    </paths>
+    <version number="3.0.0">
+        <api>
+            <source dsn=".">
+                <path>.</path>
+            </source>
+            <ignore>
+                <path>vendor/**/*</path>
+                <path>node_modules/**/*</path>
+                <path>site/**/*</path>
+                <path>docs/**/*</path>
+                <path>tests/**/*</path>
+                <path>test/**/*</path>
+                <path>.git/**/*</path>
+                <path>.github/**/*</path>
+            </ignore>
+        </api>
+    </version>
+</phpdocumentor>


### PR DESCRIPTION
I have created a comprehensive documentation structure for the project using **MkDocs** (with the Material theme) and **phpDocumentor**.

### Key Features:
1.  **Documentation Site:**
    *   Located in `docs/`.
    *   Includes sections for **Admin Guide**, **Frontend Guide**, and **Developer API**.
    *   Specific pages created for "Fetching Products", "API Variables", and "Non-JS Implementation" as requested.
    *   Added a `CONTRIBUTING.md` guide with instructions on how to contribute, including converting Word documents to Markdown.

2.  **Automated API Docs:**
    *   Configured **phpDocumentor** (`phpdoc.xml`) to scan the source code and generate API reference documentation.
    *   The API docs are integrated into the main site at `/api/`.

3.  **Deployment Workflow:**
    *   Created a GitHub Action (`.github/workflows/deploy_docs.yml`) that:
        1.  Builds the MkDocs site.
        2.  Generates the PHP API documentation into `site/api`.
        3.  Deploys the combined site to the `gh-pages` branch.
    *   This workflow triggers automatically on pushes to `dev`, `main`, or `master`.

### How to Use:
*   **Writing Docs:** Edit the Markdown files in `docs/`.
*   **Local Preview:** Run `mkdocs serve` (requires Python/MkDocs installed).
*   **Deployment:** Simply push to the `dev` branch, and the GitHub Action will handle the rest.

---
*PR created automatically by Jules for task [14291797864289949376](https://jules.google.com/task/14291797864289949376) started by @kongondo*