### PR TITLE
Add phpDocumentor configuration and setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+# phpDocumentor
+.phpdoc
+phpDocumentor.phar
+site/api
+vendor_temp
+phpdoc.log

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ https://github.com/kongondo/PWCommerce2Starter
 
 WIP
 
+### API Documentation
+
+To generate the API documentation, run the following command in the root directory:
+
+```bash
+./run_phpdoc.sh
+```
+
+This will download phpDocumentor (if not already present) and generate the documentation in `site/api`.
+
 ## Community Support Forum
 
 https://processwire.com/talk/forum/62-pwcommerce-support/

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+        xsi:noNamespaceSchemaLocation="https://docs.phpdoc.org/3.0/phpdoc.xsd"
+>
+    <title>ProcessWire Commerce API</title>
+    <paths>
+        <output>site/api</output>
+        <cache>.phpdoc/cache</cache>
+    </paths>
+    <version number="1.0.0">
+        <api>
+            <source dsn=".">
+                <path>.</path>
+            </source>
+            <extensions>
+                <extension>php</extension>
+                <extension>module</extension>
+            </extensions>
+            <ignore>
+                <path>vendor</path>
+                <path>vendor_temp</path>
+                <path>node_modules</path>
+                <path>tests</path>
+                <path>site</path>
+                <path>docs</path>
+                <path>templates</path>
+                <path>.git</path>
+                <path>.github</path>
+            </ignore>
+        </api>
+    </version>
+</phpdocumentor>

--- a/run_phpdoc.sh
+++ b/run_phpdoc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Cleanup function to restore vendor directory
+cleanup() {
+    if [ -d vendor_temp ]; then
+        mv vendor_temp vendor
+    fi
+}
+trap cleanup EXIT
+
+# Download phpDocumentor if not present
+if [ ! -f phpDocumentor.phar ]; then
+    echo "Downloading phpDocumentor..."
+    curl -L -o phpDocumentor.phar https://phpdoc.org/phpDocumentor.phar
+    chmod +x phpDocumentor.phar
+fi
+
+# Rename vendor to avoid Composer crashes in phpDocumentor
+if [ -d vendor ]; then
+    mv vendor vendor_temp
+fi
+
+# Run phpDocumentor
+echo "Running phpDocumentor..."
+php phpDocumentor.phar run


### PR DESCRIPTION
Add phpDocumentor configuration and setup script.

This commit adds `phpdoc.dist.xml` for configuring phpDocumentor v3, a script `run_phpdoc.sh` to automate the download and execution of the tool, and updates `README.md` with instructions on how to generate the API documentation. It also updates `.gitignore` to exclude generated documentation files and the PHAR.

The `run_phpdoc.sh` script temporarily renames the `vendor` directory to avoid parsing errors with dependencies, as phpDocumentor scans all PHP files in the project root by default. The configuration file explicitly ignores `vendor` and other directories.

---
*PR created automatically by Jules for task [8954351315447419519](https://jules.google.com/task/8954351315447419519) started by @kongondo*