### PR TITLE
Fix docs deployment workflow failure

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -33,10 +33,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-          tools: phpDocumentor
 
       - name: Generate API Docs
-        run: phpdoc -d . -t site/api --ignore "vendor/,node_modules/,site/,docs/,tests/,test/,.git/,.github/" --template="default"
+        run: |
+          chmod +x run_phpdoc.sh
+          ./run_phpdoc.sh
 
       # 3. Deploy to GitHub Pages
       - name: Deploy to GitHub Pages

--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -15,6 +15,7 @@
             </source>
             <ignore>
                 <path>vendor/**/*</path>
+                <path>vendor_temp/**/*</path>
                 <path>node_modules/**/*</path>
                 <path>site/**/*</path>
                 <path>docs/**/*</path>


### PR DESCRIPTION
- Updated `.github/workflows/deploy_docs.yml` to use `./run_phpdoc.sh` instead of running `phpdoc` directly. This script handles the `vendor` directory renaming to prevent `Composer\InstalledVersions` errors.
- Updated `phpdoc.xml` to ignore `vendor_temp/**/*` to ensure `phpDocumentor` does not scan the renamed vendor directory.
- Removed `tools: phpDocumentor` from `setup-php` as the script downloads the PHAR.

---
*PR created automatically by Jules for task [17428213305870352661](https://jules.google.com/task/17428213305870352661) started by @kongondo*