### PR TITLE
Fix phpDocumentor failure by restoring run_phpdoc.sh script

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -36,7 +36,7 @@ jobs:
           tools: phpDocumentor
 
       - name: Generate API Docs
-        run: phpdoc -d . -t site/api --ignore "vendor/,node_modules/,site/,docs/,tests/,test/,.git/,.github/" --template="default"
+        run: ./run_phpdoc.sh
 
       # 3. Deploy to GitHub Pages
       - name: Deploy to GitHub Pages

--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -15,6 +15,7 @@
             </source>
             <ignore>
                 <path>vendor/**/*</path>
+                <path>vendor_temp/**/*</path>
                 <path>node_modules/**/*</path>
                 <path>site/**/*</path>
                 <path>docs/**/*</path>

--- a/run_phpdoc.sh
+++ b/run_phpdoc.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mv vendor vendor_temp
+phpdoc -d . -t site/api --ignore "vendor_temp/,node_modules/,site/,docs/,tests/,test/,.git/,.github/" --template="default"
+EXIT_CODE=$?
+mv vendor_temp vendor
+exit $EXIT_CODE


### PR DESCRIPTION
Restores the `run_phpdoc.sh` script to temporarily rename `vendor` to `vendor_temp` during documentation generation, preventing `phpDocumentor` from conflicting with Composer dependencies. Updates `.github/workflows/deploy_docs.yml` to use this script and `phpdoc.xml` to ignore the temporary directory. The script now correctly captures and returns the exit code of `phpdoc`.

---
*PR created automatically by Jules for task [11916526500087969133](https://jules.google.com/task/11916526500087969133) started by @kongondo*